### PR TITLE
Adding `getAccountAsync` method to the `ITwinsAccessClient`

### DIFF
--- a/src/iTwinsAccessProps.ts
+++ b/src/iTwinsAccessProps.ts
@@ -50,6 +50,13 @@ export interface ITwinsAccess {
   getPrimaryAccountAsync(
     accessToken: AccessToken
   ): Promise<ITwinsAPIResponse<ITwin>>;
+
+  /* Get the account for an iTwin */
+  getAccountAsync(
+    accessToken: AccessToken,
+    iTwinId: string,
+    resultMode?: ITwinResultMode
+  ): Promise<ITwinsAPIResponse<ITwin>>;
 }
 
 export interface ITwinsAPIResponse<T> {
@@ -144,7 +151,7 @@ export interface ITwinsQueryArg {
 /** Set of optional arguments used for querying Respositories API
  *
  */
-export interface RepositoriesQueryArg{
+export interface RepositoriesQueryArg {
   class?: string;
   subClass?: string;
 }

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -196,6 +196,22 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
   }
 
   /**
+   * Gets the Account for the specified iTwin.
+   * @param accessToken The client access token string
+   * @param iTwinId The id of the iTwin
+   * @returns Account
+   */
+  public async getAccountAsync(
+    accessToken: AccessToken,
+    iTwinId: string,
+    resultMode?: ITwinResultMode
+  ): Promise<ITwinsAPIResponse<ITwin>> {
+    const headers = this.getResultModeHeaders(resultMode);
+    const url = `${this._baseUrl}/${iTwinId}/account`;
+    return this.sendGenericAPIRequest(accessToken, "GET", url, undefined, "iTwin", headers);
+  }
+
+  /**
    * Format headers from query arguments
    * @param arg (Optional) iTwin query arguments
    * @protected

--- a/src/test/integration/iTwinsClient.test.ts
+++ b/src/test/integration/iTwinsClient.test.ts
@@ -211,6 +211,23 @@ describe("iTwinsClient", () => {
     chai.expect(actualiTwin.createdBy).to.be.a("string");
   });
 
+  it("should get an account", async () => {
+    // Arrange
+    const iTwinId = process.env.IMJS_TEST_PROJECT_ID;
+
+    // Act
+    const iTwinsResponse: ITwinsAPIResponse<ITwin> =
+      await iTwinsAccessClient.getAccountAsync(accessToken, iTwinId!);
+
+    // Assert
+    chai.expect(iTwinsResponse.status).to.be.eq(200);
+    chai.expect(iTwinsResponse.data).to.not.be.empty;
+    const actualiTwin = iTwinsResponse.data!;
+    chai.expect(actualiTwin.id).to.not.be.eq(iTwinId); //should be a different entity
+    chai.expect(actualiTwin.class).to.be.eq("Account");
+    chai.expect(actualiTwin.subClass).to.be.eq("Account");
+  });
+
   it("should get a paged list of project iTwins using top", async () => {
     // Arrange
     const numberOfiTwins = 3;

--- a/src/test/integration/iTwinsClient.test.ts
+++ b/src/test/integration/iTwinsClient.test.ts
@@ -223,9 +223,56 @@ describe("iTwinsClient", () => {
     chai.expect(iTwinsResponse.status).to.be.eq(200);
     chai.expect(iTwinsResponse.data).to.not.be.empty;
     const actualiTwin = iTwinsResponse.data!;
+    chai.expect(actualiTwin.id).to.not.be.eq(iTwinId); // should be a different entity
+    chai.expect(actualiTwin.class).to.be.eq("Account");
+    chai.expect(actualiTwin.subClass).to.be.eq("Account");
+  });
+
+  it("should get more details for an account in represenatation result mode", async () => {
+    // Arrange
+    const iTwinId = process.env.IMJS_TEST_PROJECT_ID;
+
+    // Act
+    const iTwinsResponse: ITwinsAPIResponse<ITwin> =
+      await iTwinsAccessClient.getAccountAsync(accessToken, iTwinId!, "representation");
+
+    // Assert
+    chai.expect(iTwinsResponse.status).to.be.eq(200);
+    chai.expect(iTwinsResponse.data).to.not.be.empty;
+    const actualiTwin = iTwinsResponse.data!;
     chai.expect(actualiTwin.id).to.not.be.eq(iTwinId); //should be a different entity
     chai.expect(actualiTwin.class).to.be.eq("Account");
     chai.expect(actualiTwin.subClass).to.be.eq("Account");
+    chai.expect(actualiTwin.createdDateTime).to.be.a("string");
+    chai.expect(actualiTwin.createdBy).to.be.a("string");
+  });
+
+  it("should get the account specified by the iTwinAccountId", async () => {
+    // Arrange
+    const iTwinId = process.env.IMJS_TEST_PROJECT_ID;
+
+    // Act
+    const accountResponse: ITwinsAPIResponse<ITwin> =
+      await iTwinsAccessClient.getAccountAsync(accessToken, iTwinId!);
+    const iTwinsResponse: ITwinsAPIResponse<ITwin> =
+      await iTwinsAccessClient.getAsync(accessToken, iTwinId!);
+
+    // Assert
+    chai.expect(accountResponse.status).to.be.eq(200);
+    chai.expect(accountResponse.data).to.not.be.empty;
+    const actualAccount = accountResponse.data!;
+    chai.expect(actualAccount.id).to.not.be.eq(iTwinId); // should be a different entity
+    chai.expect(actualAccount.class).to.be.eq("Account");
+    chai.expect(actualAccount.subClass).to.be.eq("Account");
+
+    chai.expect(iTwinsResponse.status).to.be.eq(200);
+    chai.expect(iTwinsResponse.data).to.not.be.empty;
+    const actualiTwin = iTwinsResponse.data!;
+    chai.expect(actualiTwin.id).to.be.eq(iTwinId);
+    chai.expect(actualiTwin.class).to.be.eq("Endeavor");
+    chai.expect(actualiTwin.subClass).to.be.eq("Project");
+    
+    chai.expect(actualiTwin.iTwinAccountId).to.be.eq(actualAccount.id);
   });
 
   it("should get a paged list of project iTwins using top", async () => {


### PR DESCRIPTION
The `ITwinsAccessClient` was missing a method for an endpoint that existed on the iTwins API to get the account assigned to an iTwin, this PR adds a matching method and unit tests.

Closes #27 (see for more details)