### PR TITLE
Removing subClass requirement in iTwin queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## 1.6.0
 
-- Updated methods so that `subClass` is no longer mandatory
+- Updated methods so that `subClass` is no longer mandatory.
   - `queryAsync`
   - `queryFavoritesAsync`
   - `queryRecentsAsync`
+- Marked `subClass` as a depricated property.
+- Included `subClass` to be provided from the `arg` property
 
 ## 1.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@
   - `queryFavoritesAsync`
   - `queryRecentsAsync`
 - Marked `subClass` as a depricated property.
-- Included `subClass` to be provided from the `arg` property
+- Included `subClass` to be provided from the `arg` property.
 
 ## 1.5.0
 
 - Added three new properties to the `iTwin` interface.
+
   - `ianaTimeZone`
   - `imageName`
   - `image`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Change Log - @itwin/itwins-client
 
+## 1.6.0
+
+- Updated methods so that `subClass` is no longer mandatory
+  - `queryAsync`
+  - `queryFavoritesAsync`
+  - `queryRecentsAsync`
+
 ## 1.5.0
 
 - Added three new properties to the `iTwin` interface.
   - `ianaTimeZone`
   - `imageName`
   - `image`
- 
+
 - Added three new values to the `iTwinSubClass` enum.
   - Portfolio
   - Program

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 trigger:
-- main
+  - main
 
 pr:
   drafts: false
@@ -15,83 +15,83 @@ resources:
       name: iModelTechnologies/imodeljs-build-pipeline-scripts
 
 stages:
-- stage: Build
-  displayName: Build
-  jobs:
-    - job: BuildPackages
-      strategy:
-        matrix:
-          linux:
-            imageName: 'ubuntu-latest'
-          mac:
-            imageName: 'macos-latest'
-          windows:
-            imageName: 'windows-latest'
-      pool:
-        vmImage: $(imageName)
-      steps:
-      - script: npm install -g pnpm@6.19.0
-        displayName: install pnpm globally
+  - stage: Build
+    displayName: Build
+    jobs:
+      - job: BuildPackages
+        strategy:
+          matrix:
+            linux:
+              imageName: "ubuntu-latest"
+            mac:
+              imageName: "macos-latest"
+            windows:
+              imageName: "windows-latest"
+        pool:
+          vmImage: $(imageName)
+        steps:
+          - script: npm install -g pnpm
+            displayName: install pnpm globally
 
-      - script: pnpm install
-        displayName: 'Install dependencies'
+          - script: pnpm install
+            displayName: "Install dependencies"
 
-      - script: pnpm run build
-        displayName: 'Build'
+          - script: pnpm run build
+            displayName: "Build"
 
-      - script: pnpm run lint
-        displayName: 'Lint'
+          - script: pnpm run lint
+            displayName: "Lint"
 
-      - script: npm pack
-        displayName: 'Pack'
+          - script: npm pack
+            displayName: "Pack"
 
-      # publish artifact
-      - bash: |
-          itwinsClientVersion=$(node -p "require('./package.json').version")
-          itwinsClientName=$(node -p "require('./package.json').name")
-          checkVer() {
-            localVer=$1
-            name=$2
-            remoteVer=$(npm view $name version)
-            if [ -z "$remoteVer" ]; then
-              remoteVer=0.0.0
-            fi
-            olderVer=$(printf '%s\n' "$localVer" "$remoteVer" | sort -V | head -n1)
-            if [ "$localVer" != "$remoteVer" ] && [ "$remoteVer" = "$olderVer" ]; then
-              echo true
-            else
-              echo false
-            fi
-          }
-          updateClient=$(checkVer $itwinsClientVersion $itwinsClientName)
-          if [ "$updateClient" = "true" ]; then
-            echo "package publishing conditions are met."
-            shouldPublish=true
-          else
-            echo "package publishing conditions not met."
-            shouldPublish=false
-          fi
-          echo "##vso[task.setvariable variable=shouldPublish;isOutput=true]$shouldPublish"
-          echo "##vso[task.setvariable variable=itwinsClientVersion;isOutput=true]$itwinsClientVersion"
-          echo "##vso[task.setvariable variable=itwinsClientName;isOutput=true]$itwinsClientName"
-        displayName: 'Store Build Info'
-        name: info
-        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Agent.OS'], 'Linux'))
-      - task: PublishBuildArtifacts@1
-        inputs:
-          PathtoPublish: '$(Build.SourcesDirectory)/itwin-itwins-client-$(info.itwinsClientVersion).tgz'
+          # publish artifact
+          - bash: |
+              itwinsClientVersion=$(node -p "require('./package.json').version")
+              itwinsClientName=$(node -p "require('./package.json').name")
+              checkVer() {
+                localVer=$1
+                name=$2
+                remoteVer=$(npm view $name version)
+                if [ -z "$remoteVer" ]; then
+                  remoteVer=0.0.0
+                fi
+                olderVer=$(printf '%s\n' "$localVer" "$remoteVer" | sort -V | head -n1)
+                if [ "$localVer" != "$remoteVer" ] && [ "$remoteVer" = "$olderVer" ]; then
+                  echo true
+                else
+                  echo false
+                fi
+              }
+              updateClient=$(checkVer $itwinsClientVersion $itwinsClientName)
+              if [ "$updateClient" = "true" ]; then
+                echo "package publishing conditions are met."
+                shouldPublish=true
+              else
+                echo "package publishing conditions not met."
+                shouldPublish=false
+              fi
+              echo "##vso[task.setvariable variable=shouldPublish;isOutput=true]$shouldPublish"
+              echo "##vso[task.setvariable variable=itwinsClientVersion;isOutput=true]$itwinsClientVersion"
+              echo "##vso[task.setvariable variable=itwinsClientName;isOutput=true]$itwinsClientName"
+            displayName: "Store Build Info"
+            name: info
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Agent.OS'], 'Linux'))
+          - task: PublishBuildArtifacts@1
+            inputs:
+              PathtoPublish: "$(Build.SourcesDirectory)/itwin-itwins-client-$(info.itwinsClientVersion).tgz"
+              artifactName: iTwinsClient
+            displayName: "Publish iTwins client"
+            condition: and(succeeded(), eq(variables['info.shouldPublish'], 'true'))
+
+  - stage: Publish
+    displayName: Publish
+    condition: and(succeeded(), eq(dependencies.Build.outputs['BuildPackages.linux.info.shouldPublish'], 'true'))
+    dependsOn: Build
+
+    jobs:
+      - template: templates/npmjs-publish-deployment.yaml@build-pipeline-scripts
+        parameters:
+          path: "*.tgz"
           artifactName: iTwinsClient
-        displayName: 'Publish iTwins client'
-        condition: and(succeeded(), eq(variables['info.shouldPublish'], 'true'))
-
-- stage: Publish
-  displayName: Publish
-  condition: and(succeeded(), eq(dependencies.Build.outputs['BuildPackages.linux.info.shouldPublish'], 'true'))
-  dependsOn: Build
-
-  jobs:
-    - template: templates/npmjs-publish-deployment.yaml@build-pipeline-scripts
-      parameters:
-        path: '*.tgz'
-        artifactName: iTwinsClient
-        name: iTwinsClient
+          name: iTwinsClient

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/itwins-client",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "iTwins client for the iTwin platform",
   "main": "lib/cjs/itwins-client.js",
   "module": "lib/esm/itwins-client.js",

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -66,8 +66,8 @@ export class BaseClient {
           response.data.error || response.data === ""
             ? undefined
             : property
-            ? response.data[property]
-            : response.data,
+              ? response.data[property]
+              : response.data,
         error: response.data.error,
       };
     } catch (err) {
@@ -103,7 +103,7 @@ export class BaseClient {
       data,
       headers: {
         ...headers,
-        authorization: accessTokenString,
+        "authorization": accessTokenString,
         "content-type": "application/json",
       },
       validateStatus(status: number) {

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -9,13 +9,17 @@ import type { AccessToken } from "@itwin/core-bentley";
 import type { Method } from "axios";
 import type { AxiosRequestConfig } from "axios";
 import axios from "axios";
-import type { ITwinsAPIResponse, ITwinsQueryArg, RepositoriesQueryArg } from "./iTwinsAccessProps";
+import type {
+  ITwinsAPIResponse,
+  ITwinsQueryArg,
+  RepositoriesQueryArg,
+} from "./iTwinsAccessProps";
 
 export class BaseClient {
   protected _baseUrl: string = "https://api.bentley.com/itwins";
 
   public constructor(url?: string) {
-    if(url !== undefined){
+    if (url !== undefined) {
       this._baseUrl = url;
     } else {
       const urlPrefix = process.env.IMJS_URL_PREFIX;
@@ -28,14 +32,14 @@ export class BaseClient {
   }
 
   /**
-    * Sends a basic API request
-    * @param accessToken The client access token string
-    * @param method The method type of the request (ex. GET, POST, DELETE, etc.)
-    * @param url The url of the request
-    * @param data (Optional) The payload of the request
-    * @param property (Optional) The target property (ex. iTwins, repositories, etc.)
-    * @param headers (Optional) Extra request headers.
-    */
+   * Sends a basic API request
+   * @param accessToken The client access token string
+   * @param method The method type of the request (ex. GET, POST, DELETE, etc.)
+   * @param url The url of the request
+   * @param data (Optional) The payload of the request
+   * @param property (Optional) The target property (ex. iTwins, repositories, etc.)
+   * @param headers (Optional) Extra request headers.
+   */
   protected async sendGenericAPIRequest(
     accessToken: AccessToken,
     method: Method,
@@ -43,15 +47,27 @@ export class BaseClient {
     data?: any,
     property?: string,
     headers?: Record<string, string | number | boolean>
-  ): Promise<ITwinsAPIResponse<any>> { // TODO: Change any response
-    const requestOptions = this.getRequestOptions(accessToken, method, url, data, headers);
+  ): Promise<ITwinsAPIResponse<any>> {
+    // TODO: Change any response
+    const requestOptions = this.getRequestOptions(
+      accessToken,
+      method,
+      url,
+      data,
+      headers
+    );
 
     try {
       const response = await axios(requestOptions);
 
       return {
         status: response.status,
-        data: response.data.error || response.data === "" ? undefined : property ? response.data[property] : response.data,
+        data:
+          response.data.error || response.data === ""
+            ? undefined
+            : property
+            ? response.data[property]
+            : response.data,
         error: response.data.error,
       };
     } catch (err) {
@@ -60,20 +76,20 @@ export class BaseClient {
         error: {
           code: "InternalServerError",
           message:
-             "An internal exception happened while calling iTwins Service",
+            "An internal exception happened while calling iTwins Service",
         },
       };
     }
   }
 
   /**
-    * Build the request methods, headers, and other options
-    * @param accessTokenString The client access token string
-    * @param method The method type of the request (ex. GET, POST, DELETE, etc.)
-    * @param url The url of the request
-    * @param data (Optional) The payload of the request
-    * @param headers (Optional) Extra request headers.
-    */
+   * Build the request methods, headers, and other options
+   * @param accessTokenString The client access token string
+   * @param method The method type of the request (ex. GET, POST, DELETE, etc.)
+   * @param url The url of the request
+   * @param data (Optional) The payload of the request
+   * @param headers (Optional) Extra request headers.
+   */
   protected getRequestOptions(
     accessTokenString: string,
     method: Method,
@@ -87,20 +103,20 @@ export class BaseClient {
       data,
       headers: {
         ...headers,
-        "authorization": accessTokenString,
+        authorization: accessTokenString,
         "content-type": "application/json",
       },
-      validateStatus(status) {
+      validateStatus(status: number) {
         return status < 500; // Resolve only if the status code is less than 500
       },
     };
   }
 
   /**
-    * Build a query to be appended to a URL
-    * @param queryArg Object container queryable properties
-    * @returns query string with AccessControlQueryArg applied, which should be appended to a url
-    */
+   * Build a query to be appended to a URL
+   * @param queryArg Object container queryable properties
+   * @returns query string with AccessControlQueryArg applied, which should be appended to a url
+   */
   protected getQueryString(queryArg: ITwinsQueryArg): string {
     let queryString = "";
 

--- a/src/iTwinsAccessProps.ts
+++ b/src/iTwinsAccessProps.ts
@@ -15,7 +15,7 @@ export interface ITwinsAccess {
   /** Get iTwins */
   queryAsync(
     accessToken: AccessToken,
-    subClass: ITwinSubClass,
+    subClass?: ITwinSubClass,
     arg?: ITwinsQueryArg
   ): Promise<ITwinsAPIResponse<ITwin[]>>;
 
@@ -35,14 +35,14 @@ export interface ITwinsAccess {
   /** Get favorited iTwins */
   queryFavoritesAsync(
     accessToken: AccessToken,
-    subClass: ITwinSubClass,
+    subClass?: ITwinSubClass,
     arg?: ITwinsQueryArg
   ): Promise<ITwinsAPIResponse<ITwin[]>>;
 
   /** Get recent iTwins */
   queryRecentsAsync(
     accessToken: AccessToken,
-    subClass: ITwinSubClass,
+    subClass?: ITwinSubClass,
     arg?: ITwinsQueryArg
   ): Promise<ITwinsAPIResponse<ITwin[]>>;
 

--- a/src/iTwinsAccessProps.ts
+++ b/src/iTwinsAccessProps.ts
@@ -152,6 +152,7 @@ export interface ITwinsQueryArg {
   type?: string;
   resultMode?: ITwinResultMode;
   queryScope?: ITwinQueryScope;
+  subClass?: ITwinSubClass;
 }
 
 /** Set of optional arguments used for querying Respositories API

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -45,10 +45,9 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = this._baseUrl;
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
-    if (subClass || arg?.subClass){
-      // eslint-disable-next-line deprecation/deprecation
-      query += `subClass=${subClass ?? arg?.subClass}`;
-    }
+    const resolvedSubClass = subClass !== undefined ? subClass : arg?.subClass;
+    if (resolvedSubClass)
+      query += `subClass=${resolvedSubClass}`;
     if (arg)
       query += this.getQueryString(arg);
     if (query !== "")
@@ -179,10 +178,10 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = `${this._baseUrl}/favorites`;
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
-    if (subClass || arg?.subClass){
-      // eslint-disable-next-line deprecation/deprecation
-      query += `subClass=${subClass ?? arg?.subClass}`;
-    }
+    const resolvedSubClass = subClass !== undefined ? subClass : arg?.subClass;
+    if (resolvedSubClass)
+      query += `subClass=${resolvedSubClass}`;
+
 
     if (arg)
       query += this.getQueryString(arg);
@@ -210,10 +209,9 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = `${this._baseUrl}/recents`;
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
-    if (subClass || arg?.subClass){
-      // eslint-disable-next-line deprecation/deprecation
-      query += `subClass=${subClass ?? arg?.subClass}`;
-    }
+    const resolvedSubClass = subClass !== undefined ? subClass : arg?.subClass;;
+    if (resolvedSubClass)
+      query += `subClass=${resolvedSubClass}`;
     if (arg)
       query += this.getQueryString(arg);
     if (query !== "")

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -46,7 +46,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
     let resolvedSubClass = subClass;
-    if(arg !== undefined && arg.subClass !== undefined)
+    if(arg && arg.subClass)
       resolvedSubClass = arg.subClass;
     if (resolvedSubClass)
       query += `subClass=${resolvedSubClass}`;
@@ -181,7 +181,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
     let resolvedSubClass = subClass;
-    if(arg !== undefined && arg.subClass !== undefined)
+    if(arg && arg.subClass)
       resolvedSubClass = arg.subClass;
     if (resolvedSubClass)
       query += `subClass=${resolvedSubClass}`;
@@ -212,7 +212,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
     let resolvedSubClass = subClass;
-    if(arg !== undefined && arg.subClass !== undefined)
+    if(arg && arg.subClass)
       resolvedSubClass = arg.subClass;
     if (resolvedSubClass)
       query += `subClass=${resolvedSubClass}`;

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -181,8 +181,6 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     const resolvedSubClass = subClass !== undefined ? subClass : arg?.subClass;
     if (resolvedSubClass)
       query += `subClass=${resolvedSubClass}`;
-
-
     if (arg)
       query += this.getQueryString(arg);
     if (query !== "")
@@ -209,7 +207,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = `${this._baseUrl}/recents`;
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
-    const resolvedSubClass = subClass !== undefined ? subClass : arg?.subClass;;
+    const resolvedSubClass = subClass !== undefined ? subClass : arg?.subClass;
     if (resolvedSubClass)
       query += `subClass=${resolvedSubClass}`;
     if (arg)

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -36,7 +36,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
   public async queryAsync(
     accessToken: AccessToken,
     /**
-     * @deprecated in 1.6 This property is deprecated, and will be removed in the next major release. Please use `arg` to provide subClass instead.
+     * @deprecated in 2.0 This property is deprecated, and will be removed in the next major release. Please use `arg` to provide subClass instead.
      */
     subClass?: ITwinSubClass,
     arg?: ITwinsQueryArg
@@ -44,7 +44,9 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     const headers = this.getHeaders(arg);
     let url = this._baseUrl;
     let query = "";
+    // eslint-disable-next-line deprecation/deprecation
     if (subClass || arg?.subClass)
+      // eslint-disable-next-line deprecation/deprecation
       query += `subClass=${subClass ?? arg?.subClass}`;
     if (arg)
       query += this.getQueryString(arg);
@@ -167,7 +169,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
   public async queryFavoritesAsync(
     accessToken: AccessToken,
     /**
-     * @deprecated in 1.6 This property is deprecated, and will be removed in the next major release. Please use `arg` to provide subClass instead.
+     * @deprecated in 2.0 This property is deprecated, and will be removed in the next major release. Please use `arg` to provide subClass instead.
      */
     subClass?: ITwinSubClass,
     arg?: ITwinsQueryArg
@@ -175,7 +177,9 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     const headers = this.getHeaders(arg);
     let url = `${this._baseUrl}/favorites`;
     let query = "";
+    // eslint-disable-next-line deprecation/deprecation
     if (subClass || arg?.subClass)
+      // eslint-disable-next-line deprecation/deprecation
       query += `subClass=${subClass ?? arg?.subClass}`;
     if (arg)
       query += this.getQueryString(arg);
@@ -194,7 +198,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
   public async queryRecentsAsync(
     accessToken: AccessToken,
     /**
-     * @deprecated in 1.6 This property is deprecated, and will be removed in the next major release. Please use `arg` to provide subClass instead.
+     * @deprecated in 2.0 This property is deprecated, and will be removed in the next major release. Please use `arg` to provide subClass instead.
      */
     subClass?: ITwinSubClass,
     arg?: ITwinsQueryArg
@@ -202,7 +206,9 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     const headers = this.getHeaders(arg);
     let url = `${this._baseUrl}/recents`;
     let query = "";
+    // eslint-disable-next-line deprecation/deprecation
     if (subClass || arg?.subClass)
+      // eslint-disable-next-line deprecation/deprecation
       query += `subClass=${subClass ?? arg?.subClass}`;
     if (arg)
       query += this.getQueryString(arg);

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -35,14 +35,17 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
    */
   public async queryAsync(
     accessToken: AccessToken,
+    /**
+     * @deprecated in 1.6 This property is deprecated, and will be removed in the next major release. Please use `arg` to provide subClass instead.
+     */
     subClass?: ITwinSubClass,
     arg?: ITwinsQueryArg
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
     const headers = this.getHeaders(arg);
     let url = this._baseUrl;
     let query = "";
-    if (subClass)
-      query += `subClass=${subClass}`;
+    if (subClass || arg?.subClass)
+      query += `subClass=${subClass ?? arg?.subClass}`;
     if (arg)
       query += this.getQueryString(arg);
     if (query !== "")
@@ -163,14 +166,17 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
    */
   public async queryFavoritesAsync(
     accessToken: AccessToken,
+    /**
+     * @deprecated in 1.6 This property is deprecated, and will be removed in the next major release. Please use `arg` to provide subClass instead.
+     */
     subClass?: ITwinSubClass,
     arg?: ITwinsQueryArg
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
     const headers = this.getHeaders(arg);
     let url = `${this._baseUrl}/favorites`;
     let query = "";
-    if (subClass)
-      query += `subClass=${subClass}`;
+    if (subClass || arg?.subClass)
+      query += `subClass=${subClass ?? arg?.subClass}`;
     if (arg)
       query += this.getQueryString(arg);
     if (query !== "")
@@ -187,14 +193,17 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
    */
   public async queryRecentsAsync(
     accessToken: AccessToken,
+    /**
+     * @deprecated in 1.6 This property is deprecated, and will be removed in the next major release. Please use `arg` to provide subClass instead.
+     */
     subClass?: ITwinSubClass,
     arg?: ITwinsQueryArg
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
     const headers = this.getHeaders(arg);
     let url = `${this._baseUrl}/recents`;
     let query = "";
-    if (subClass)
-      query += `subClass=${subClass}`;
+    if (subClass || arg?.subClass)
+      query += `subClass=${subClass ?? arg?.subClass}`;
     if (arg)
       query += this.getQueryString(arg);
     if (query !== "")

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -45,9 +45,10 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = this._baseUrl;
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
-    if (subClass || arg?.subClass)
+    if (subClass || arg?.subClass){
       // eslint-disable-next-line deprecation/deprecation
       query += `subClass=${subClass ?? arg?.subClass}`;
+    }
     if (arg)
       query += this.getQueryString(arg);
     if (query !== "")
@@ -178,9 +179,11 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = `${this._baseUrl}/favorites`;
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
-    if (subClass || arg?.subClass)
+    if (subClass || arg?.subClass){
       // eslint-disable-next-line deprecation/deprecation
       query += `subClass=${subClass ?? arg?.subClass}`;
+    }
+
     if (arg)
       query += this.getQueryString(arg);
     if (query !== "")
@@ -207,9 +210,10 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = `${this._baseUrl}/recents`;
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
-    if (subClass || arg?.subClass)
+    if (subClass || arg?.subClass){
       // eslint-disable-next-line deprecation/deprecation
       query += `subClass=${subClass ?? arg?.subClass}`;
+    }
     if (arg)
       query += this.getQueryString(arg);
     if (query !== "")

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -29,19 +29,25 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
 
   /** Get itwins accessible to the user
    * @param accessToken The client access token string
-   * @param subClass Required parameter to search a specific iTwin subClass
+   * @param subClass Optional parameter to search a specific iTwin subClass
    * @param arg Optional query arguments, for paging, searching, and filtering
    * @returns Array of projects, may be empty
    */
   public async queryAsync(
     accessToken: AccessToken,
-    subClass: ITwinSubClass,
+    subClass?: ITwinSubClass,
     arg?: ITwinsQueryArg
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
     const headers = this.getHeaders(arg);
-    let url = `${this._baseUrl}?subClass=${subClass}`;
+    let url = this._baseUrl;
+    let query = "";
+    if (subClass)
+      query += `subClass=${subClass}`;
     if (arg)
-      url += this.getQueryString(arg);
+      query += this.getQueryString(arg);
+    if (query !== "")
+      url += `?${query}`;
+
     return this.sendGenericAPIRequest(accessToken, "GET", url, undefined, "iTwins", headers);
   }
 
@@ -151,37 +157,49 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
 
   /** Get itwins accessible to the user
    * @param accessToken The client access token string
-   * @param subClass Required parameter to search a specific iTwin subClass
+   * @param subClass Optional parameter to search a specific iTwin subClass
    * @param arg Optional query arguments, for paging, searching, and filtering
    * @returns Array of projects, may be empty
    */
   public async queryFavoritesAsync(
     accessToken: AccessToken,
-    subClass: ITwinSubClass,
+    subClass?: ITwinSubClass,
     arg?: ITwinsQueryArg
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
     const headers = this.getHeaders(arg);
-    let url = `${this._baseUrl}/favorites?subClass=${subClass}`;
+    let url = `${this._baseUrl}/favorites`;
+    let query = "";
+    if (subClass)
+      query += `subClass=${subClass}`;
     if (arg)
-      url += this.getQueryString(arg);
+      query += this.getQueryString(arg);
+    if (query !== "")
+      url += `?${query}`;
+
     return this.sendGenericAPIRequest(accessToken, "GET", url, undefined, "iTwins", headers);
   }
 
   /** Get itwins accessible to the user
    * @param accessToken The client access token string
-   * @param subClass Required parameter to search a specific iTwin subClass
+   * @param subClass Optional parameter to search a specific iTwin subClass
    * @param arg Optional query arguments, for paging, searching, and filtering
    * @returns Array of projects, may be empty
    */
   public async queryRecentsAsync(
     accessToken: AccessToken,
-    subClass: ITwinSubClass,
+    subClass?: ITwinSubClass,
     arg?: ITwinsQueryArg
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
     const headers = this.getHeaders(arg);
-    let url = `${this._baseUrl}/recents?subClass=${subClass}`;
+    let url = `${this._baseUrl}/recents`;
+    let query = "";
+    if (subClass)
+      query += `subClass=${subClass}`;
     if (arg)
-      url += this.getQueryString(arg);
+      query += this.getQueryString(arg);
+    if (query !== "")
+      url += `?${query}`;
+
     return this.sendGenericAPIRequest(accessToken, "GET", url, undefined, "iTwins", headers);
   }
 

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -45,7 +45,9 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = this._baseUrl;
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
-    const resolvedSubClass = subClass !== undefined ? subClass : (arg && arg.subClass);
+    let resolvedSubClass = subClass;
+    if(arg !== undefined && arg.subClass !== undefined)
+      resolvedSubClass = arg.subClass;
     if (resolvedSubClass)
       query += `subClass=${resolvedSubClass}`;
     if (arg)
@@ -178,7 +180,9 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = `${this._baseUrl}/favorites`;
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
-    const resolvedSubClass = subClass !== undefined ? subClass : (arg && arg.subClass);
+    let resolvedSubClass = subClass;
+    if(arg !== undefined && arg.subClass !== undefined)
+      resolvedSubClass = arg.subClass;
     if (resolvedSubClass)
       query += `subClass=${resolvedSubClass}`;
     if (arg)
@@ -207,7 +211,9 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = `${this._baseUrl}/recents`;
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
-    const resolvedSubClass = subClass !== undefined ? subClass : (arg && arg.subClass);
+    let resolvedSubClass = subClass;
+    if(arg !== undefined && arg.subClass !== undefined)
+      resolvedSubClass = arg.subClass;
     if (resolvedSubClass)
       query += `subClass=${resolvedSubClass}`;
     if (arg)

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -45,7 +45,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = this._baseUrl;
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
-    const resolvedSubClass = subClass !== undefined ? subClass : arg?.subClass;
+    const resolvedSubClass = subClass !== undefined ? subClass : (arg && arg.subClass);
     if (resolvedSubClass)
       query += `subClass=${resolvedSubClass}`;
     if (arg)
@@ -178,7 +178,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = `${this._baseUrl}/favorites`;
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
-    const resolvedSubClass = subClass !== undefined ? subClass : arg?.subClass;
+    const resolvedSubClass = subClass !== undefined ? subClass : (arg && arg.subClass);
     if (resolvedSubClass)
       query += `subClass=${resolvedSubClass}`;
     if (arg)
@@ -207,7 +207,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = `${this._baseUrl}/recents`;
     let query = "";
     // eslint-disable-next-line deprecation/deprecation
-    const resolvedSubClass = subClass !== undefined ? subClass : arg?.subClass;
+    const resolvedSubClass = subClass !== undefined ? subClass : (arg && arg.subClass);
     if (resolvedSubClass)
       query += `subClass=${resolvedSubClass}`;
     if (arg)

--- a/src/test/integration/iTwinsClient.test.ts
+++ b/src/test/integration/iTwinsClient.test.ts
@@ -48,6 +48,18 @@ describe("iTwinsClient", () => {
     chai.expect(iTwinsResponse.data).to.not.be.empty;
   });
 
+  it("should get a list of project iTwins with provided subClass inside arg", async () => {
+    // Act
+    const iTwinsResponse: ITwinsAPIResponse<ITwin[]> =
+      await iTwinsCustomClient.queryAsync(accessToken, undefined, {
+        subClass: ITwinSubClass.Project,
+      });
+
+    // Assert
+    chai.expect(iTwinsResponse.status).to.be.eq(200);
+    chai.expect(iTwinsResponse.data).to.not.be.empty;
+  });
+
   it("should get iTwin repositories by id", async () => {
     // Arrange
     const iTwinId = "e01065ed-c52b-4ddf-a326-e7845442716d";

--- a/src/test/integration/iTwinsClient.test.ts
+++ b/src/test/integration/iTwinsClient.test.ts
@@ -563,10 +563,6 @@ describe("iTwinsClient", () => {
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(200);
     chai.expect(iTwinsResponse.data).to.not.be.empty;
-    iTwinsResponse.data!.forEach((actualiTwin) => {
-      chai.expect(actualiTwin.class).to.be.eq("Endeavor");
-      chai.expect(actualiTwin.subClass).to.be.eq("Project");
-    });
   });
 
   it("should get more properties of favorited project iTwins in representation result mode", async () => {

--- a/src/test/integration/iTwinsClient.test.ts
+++ b/src/test/integration/iTwinsClient.test.ts
@@ -38,6 +38,16 @@ describe("iTwinsClient", () => {
     chai.expect(iTwinsResponse.data).to.not.be.empty;
   });
 
+  it("should get a list of project iTwins without provided subClass", async () => {
+    // Act
+    const iTwinsResponse: ITwinsAPIResponse<ITwin[]> =
+      await iTwinsCustomClient.queryAsync(accessToken);
+
+    // Assert
+    chai.expect(iTwinsResponse.status).to.be.eq(200);
+    chai.expect(iTwinsResponse.data).to.not.be.empty;
+  });
+
   it("should get iTwin repositories by id", async () => {
     // Arrange
     const iTwinId = "e01065ed-c52b-4ddf-a326-e7845442716d";
@@ -172,6 +182,16 @@ describe("iTwinsClient", () => {
     // Act
     const iTwinsResponse: ITwinsAPIResponse<ITwin[]> =
       await iTwinsAccessClient.queryAsync(accessToken, ITwinSubClass.Project);
+
+    // Assert
+    chai.expect(iTwinsResponse.status).to.be.eq(200);
+    chai.expect(iTwinsResponse.data).to.not.be.empty;
+  });
+
+  it("should get a list of project iTwins without providing subClass", async () => {
+    // Act
+    const iTwinsResponse: ITwinsAPIResponse<ITwin[]> =
+      await iTwinsAccessClient.queryAsync(accessToken);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(200);
@@ -481,6 +501,18 @@ describe("iTwinsClient", () => {
     chai.expect(iTwinsResponse.data).to.not.be.empty;
   });
 
+  it("should get a list of recent project iTwins without subClass query", async () => {
+    // Act
+    const iTwinsResponse: ITwinsAPIResponse<ITwin[]> =
+      await iTwinsAccessClient.queryRecentsAsync(
+        accessToken
+      );
+
+    // Assert
+    chai.expect(iTwinsResponse.status).to.be.eq(200);
+    chai.expect(iTwinsResponse.data).to.not.be.empty;
+  });
+
   it("should get more properties of recent project iTwins in representation result mode", async () => {
     // Act
     const iTwinsResponse: ITwinsAPIResponse<ITwin[]> =
@@ -510,6 +542,22 @@ describe("iTwinsClient", () => {
       await iTwinsAccessClient.queryFavoritesAsync(
         accessToken,
         ITwinSubClass.Project
+      );
+
+    // Assert
+    chai.expect(iTwinsResponse.status).to.be.eq(200);
+    chai.expect(iTwinsResponse.data).to.not.be.empty;
+    iTwinsResponse.data!.forEach((actualiTwin) => {
+      chai.expect(actualiTwin.class).to.be.eq("Endeavor");
+      chai.expect(actualiTwin.subClass).to.be.eq("Project");
+    });
+  });
+
+  it("should get a list of favorited project iTwins without subClass query", async () => {
+    // Act
+    const iTwinsResponse: ITwinsAPIResponse<ITwin[]> =
+      await iTwinsAccessClient.queryFavoritesAsync(
+        accessToken
       );
 
     // Assert


### PR DESCRIPTION
iTwins API no longer requires `subClass` as a mandatory query parameter. Making sure the client have this change reflected.

Api affected:
- https://developer.bentley.com/apis/itwins/operations/get-my-itwins/
- https://developer.bentley.com/apis/itwins/operations/get-my-recently-used-itwins/
- https://developer.bentley.com/apis/itwins/operations/get-my-favorite-itwins/