### PR TITLE
Include missing properties from query parameters from iTwin endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log - @itwin/itwins-client
 
+## 1.6.1
+
+- Added missing properties when accesing these methods:
+  - `queryAsync`
+  - `queryFavoritesAsync`
+  - `queryRecentsAsync`
+- Missing properties:
+  - `includeInactive`
+  - `status`
+  - `subClass`
+  - `parentId`
+  - `iTwinAccountId`
+
 ## 1.6.0
 
 - Updated methods so that `subClass` is no longer mandatory.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/itwins-client",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "iTwins client for the iTwin platform",
   "main": "lib/cjs/itwins-client.js",
   "module": "lib/esm/itwins-client.js",

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -122,33 +122,33 @@ export class BaseClient {
   protected getQueryStringArgBase(queryArg?: ITwinsQueryArgBase, subClass?: ITwinSubClass): string {
     let queryString = "";
 
-    if (subClass) {
+    if (subClass !== undefined ) {
       queryString += `subClass=${subClass}`;
-    } else if (queryArg && queryArg.subClass) {
+    } else if (queryArg !== undefined && queryArg.subClass !== undefined) {
       queryString += `subClass=${queryArg.subClass}`;
     }
 
-    if(!queryArg) {
+    if(queryArg === undefined) {
       return queryString;
     }
 
-    if (queryArg.includeInactive) {
+    if (queryArg.includeInactive !== undefined) {
       queryString += `&includeInactive=${queryArg.includeInactive}`;
     }
 
-    if (queryArg.top) {
+    if (queryArg.top !== undefined) {
       queryString += `&$top=${queryArg.top}`;
     }
 
-    if (queryArg.skip) {
+    if (queryArg.skip !== undefined) {
       queryString += `&$skip=${queryArg.skip}`;
     }
 
-    if (queryArg.status) {
+    if (queryArg.status !== undefined) {
       queryString += `&status=${queryArg.status}`;
     }
 
-    if (queryArg.type) {
+    if (queryArg.type !== undefined) {
       queryString += `&type=${queryArg.type}`;
     }
 
@@ -166,27 +166,27 @@ export class BaseClient {
   protected getQueryStringArg(queryArg?: ITwinsQueryArg, subClass?: ITwinSubClass): string {
     let queryString = this.getQueryStringArgBase(queryArg, subClass);
 
-    if(!queryArg) {
+    if(queryArg === undefined) {
       return queryString;
     }
 
-    if (queryArg.search) {
+    if (queryArg.search !== undefined) {
       queryString += `&includeInactive=${queryArg.search}`;
     }
 
-    if (queryArg.displayName) {
+    if (queryArg.displayName !== undefined) {
       queryString += `&$top=${queryArg.displayName}`;
     }
 
-    if (queryArg.number) {
+    if (queryArg.number !== undefined) {
       queryString += `&$skip=${queryArg.number}`;
     }
 
-    if (queryArg.parentId) {
+    if (queryArg.parentId !== undefined) {
       queryString += `&status=${queryArg.parentId}`;
     }
 
-    if (queryArg.iTwinAccountId) {
+    if (queryArg.iTwinAccountId !== undefined) {
       queryString += `&type=${queryArg.iTwinAccountId}`;
     }
 
@@ -204,11 +204,11 @@ export class BaseClient {
   protected getRepositoryQueryString(queryArg: RepositoriesQueryArg): string {
     let queryString = "";
 
-    if (queryArg.class) {
-      queryString += `?class=${queryArg.class}`;
+    if (queryArg.class !== undefined) {
+      queryString += `class=${queryArg.class}`;
     }
 
-    if (queryArg.subClass) {
+    if (queryArg.subClass !== undefined) {
       queryString += `&subClass=${queryArg.subClass}`;
     }
 

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -119,11 +119,20 @@ export class BaseClient {
    * @param queryArg Object container queryable properties
    * @returns query string with AccessControlQueryArg applied, which should be appended to a url
    */
-  protected getQueryString(queryArg: ITwinsQueryArg, subClass?: ITwinSubClass): string {
+  protected getQueryString(queryArg?: ITwinsQueryArg, subClass?: ITwinSubClass): string {
     let queryString = "";
 
-    if(subClass || queryArg.subClass) {
-      queryString += `&subClass=${subClass ?? queryArg.subClass}`;
+    if(subClass || (queryArg && queryArg.subClass)) {
+      let resolvedSubClass = subClass;
+      if(queryArg && queryArg.subClass) {
+        resolvedSubClass = queryArg?.subClass;
+      }
+
+      queryString += `&subClass=${resolvedSubClass}`;
+    }
+
+    if(!queryArg) {
+      return queryString;
     }
 
     if (queryArg.includeInactive) {
@@ -177,11 +186,20 @@ export class BaseClient {
     * @param queryArg Object container queryable properties
     * @returns query string with AccessControlQueryArg applied, which should be appended to a url
     */
-  protected getQueryStringArgBase(queryArg: ITwinsQueryArgBase, subClass?: ITwinSubClass): string {
+  protected getQueryStringArgBase(queryArg?: ITwinsQueryArgBase, subClass?: ITwinSubClass): string {
     let queryString = "";
 
-    if(subClass || queryArg.subClass) {
-      queryString += `&subClass=${subClass ?? queryArg.subClass}`;
+    if(subClass || (queryArg && queryArg.subClass)) {
+      let resolvedSubClass = subClass;
+      if(queryArg && queryArg.subClass) {
+        resolvedSubClass = queryArg?.subClass;
+      }
+
+      queryString += `&subClass=${resolvedSubClass}`;
+    }
+
+    if(!queryArg) {
+      return queryString;
     }
 
     if (queryArg.includeInactive) {

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -122,10 +122,10 @@ export class BaseClient {
   protected getQueryStringArgBase(queryArg?: ITwinsQueryArgBase, subClass?: ITwinSubClass): string {
     let queryString = "";
 
-    if (subClass) {
-      queryString += `subClass=${subClass}`;
-    } else if (queryArg && queryArg.subClass) {
+    if (queryArg && queryArg.subClass) {
       queryString += `subClass=${queryArg.subClass}`;
+    } else if (subClass) {
+      queryString += `subClass=${subClass}`;
     }
 
     if(!queryArg) {

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -9,7 +9,7 @@ import type { AccessToken } from "@itwin/core-bentley";
 import type { Method } from "axios";
 import type { AxiosRequestConfig } from "axios";
 import axios from "axios";
-import type { ITwinsAPIResponse, ITwinsQueryArg, RepositoriesQueryArg } from "./iTwinsAccessProps";
+import type { ITwinsAPIResponse, ITwinsQueryArg, ITwinsQueryArgBase, RepositoriesQueryArg } from "./iTwinsAccessProps";
 
 export class BaseClient {
   protected _baseUrl: string = "https://api.bentley.com/itwins";
@@ -104,8 +104,8 @@ export class BaseClient {
   protected getQueryString(queryArg: ITwinsQueryArg): string {
     let queryString = "";
 
-    if (queryArg.search) {
-      queryString += `&$search=${queryArg.search}`;
+    if (queryArg.includeInactive) {
+      queryString += `&includeInactive=${queryArg.includeInactive}`;
     }
 
     if (queryArg.top) {
@@ -116,12 +116,70 @@ export class BaseClient {
       queryString += `&$skip=${queryArg.skip}`;
     }
 
+    if (queryArg.status) {
+      queryString += `&status=${queryArg.status}`;
+    }
+
+    if (queryArg.subClass) {
+      queryString += `&subClass=${queryArg.subClass}`;
+    }
+
+    if (queryArg.type) {
+      queryString += `&type=${queryArg.type}`;
+    }
+
+    if (queryArg.search) {
+      queryString += `&$search=${queryArg.search}`;
+    }
+
     if (queryArg.displayName) {
       queryString += `&displayName=${queryArg.displayName}`;
     }
 
     if (queryArg.number) {
       queryString += `&number=${queryArg.number}`;
+    }
+
+    if (queryArg.parentId) {
+      queryString += `&parentId=${queryArg.parentId}`;
+    }
+
+    if (queryArg.iTwinAccountId) {
+      queryString += `&iTwinAccountId=${queryArg.iTwinAccountId}`;
+    }
+
+    // trim & from start of string
+    queryString.replace(/^&+/, "");
+
+    return queryString;
+  }
+
+  /**
+    * Build a query to be appended to a URL
+    * @param queryArg Object container queryable properties
+    * @returns query string with AccessControlQueryArg applied, which should be appended to a url
+    */
+  protected getQueryStringArgBase(queryArg: ITwinsQueryArgBase): string {
+    let queryString = "";
+
+    if (queryArg.includeInactive) {
+      queryString += `&includeInactive=${queryArg.includeInactive}`;
+    }
+
+    if (queryArg.top) {
+      queryString += `&$top=${queryArg.top}`;
+    }
+
+    if (queryArg.skip) {
+      queryString += `&$skip=${queryArg.skip}`;
+    }
+
+    if (queryArg.status) {
+      queryString += `&status=${queryArg.status}`;
+    }
+
+    if (queryArg.subClass) {
+      queryString += `&subClass=${queryArg.subClass}`;
     }
 
     if (queryArg.type) {

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -13,6 +13,7 @@ import type {
   ITwinsAPIResponse,
   ITwinsQueryArg,
   ITwinsQueryArgBase,
+  ITwinSubClass,
   RepositoriesQueryArg,
 } from "./iTwinsAccessProps";
 
@@ -118,8 +119,12 @@ export class BaseClient {
    * @param queryArg Object container queryable properties
    * @returns query string with AccessControlQueryArg applied, which should be appended to a url
    */
-  protected getQueryString(queryArg: ITwinsQueryArg): string {
+  protected getQueryString(queryArg: ITwinsQueryArg, subClass?: ITwinSubClass): string {
     let queryString = "";
+
+    if(subClass || queryArg.subClass) {
+      queryString += `&subClass=${subClass || queryArg.subClass}`;
+    }
 
     if (queryArg.includeInactive) {
       queryString += `&includeInactive=${queryArg.includeInactive}`;
@@ -135,10 +140,6 @@ export class BaseClient {
 
     if (queryArg.status) {
       queryString += `&status=${queryArg.status}`;
-    }
-
-    if (queryArg.subClass) {
-      queryString += `&subClass=${queryArg.subClass}`;
     }
 
     if (queryArg.type) {
@@ -176,8 +177,12 @@ export class BaseClient {
     * @param queryArg Object container queryable properties
     * @returns query string with AccessControlQueryArg applied, which should be appended to a url
     */
-  protected getQueryStringArgBase(queryArg: ITwinsQueryArgBase): string {
+  protected getQueryStringArgBase(queryArg: ITwinsQueryArgBase, subClass?: ITwinSubClass): string {
     let queryString = "";
+
+    if(subClass || queryArg.subClass) {
+      queryString += `&subClass=${subClass || queryArg.subClass}`;
+    }
 
     if (queryArg.includeInactive) {
       queryString += `&includeInactive=${queryArg.includeInactive}`;
@@ -193,10 +198,6 @@ export class BaseClient {
 
     if (queryArg.status) {
       queryString += `&status=${queryArg.status}`;
-    }
-
-    if (queryArg.subClass) {
-      queryString += `&subClass=${queryArg.subClass}`;
     }
 
     if (queryArg.type) {

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -128,7 +128,7 @@ export class BaseClient {
       queryString += `subClass=${queryArg.subClass}`;
     }
 
-    if(queryArg === undefined) {
+    if(!queryArg) {
       return queryString;
     }
 
@@ -166,7 +166,7 @@ export class BaseClient {
   protected getQueryStringArg(queryArg?: ITwinsQueryArg, subClass?: ITwinSubClass): string {
     let queryString = this.getQueryStringArgBase(queryArg, subClass);
 
-    if(queryArg === undefined) {
+    if(!queryArg) {
       return queryString;
     }
 
@@ -204,11 +204,11 @@ export class BaseClient {
   protected getRepositoryQueryString(queryArg: RepositoriesQueryArg): string {
     let queryString = "";
 
-    if (queryArg.class !== undefined) {
+    if (queryArg.class) {
       queryString += `class=${queryArg.class}`;
     }
 
-    if (queryArg.subClass !== undefined) {
+    if (queryArg.subClass) {
       queryString += `&subClass=${queryArg.subClass}`;
     }
 

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -122,8 +122,10 @@ export class BaseClient {
   protected getQueryString(queryArg?: ITwinsQueryArg, subClass?: ITwinSubClass): string {
     let queryString = "";
 
-    if(subClass || queryArg?.subClass) {
-      queryString += `&subClass=${subClass ?? queryArg?.subClass}`;
+    if (subClass) {
+      queryString += `&subClass=${subClass}`;
+    } else if (queryArg && queryArg.subClass) {
+      queryString += `&subClass=${queryArg.subClass}`;
     }
 
     if(!queryArg) {
@@ -184,8 +186,10 @@ export class BaseClient {
   protected getQueryStringArgBase(queryArg?: ITwinsQueryArgBase, subClass?: ITwinSubClass): string {
     let queryString = "";
 
-    if(subClass || queryArg?.subClass) {
-      queryString += `&subClass=${subClass ?? queryArg?.subClass}`;
+    if (subClass) {
+      queryString += `&subClass=${subClass}`;
+    } else if (queryArg && queryArg.subClass) {
+      queryString += `&subClass=${queryArg.subClass}`;
     }
 
     if(!queryArg) {

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -125,7 +125,7 @@ export class BaseClient {
     if(subClass || (queryArg && queryArg.subClass)) {
       let resolvedSubClass = subClass;
       if(queryArg && queryArg.subClass) {
-        resolvedSubClass = queryArg?.subClass;
+        resolvedSubClass = queryArg.subClass;
       }
 
       queryString += `&subClass=${resolvedSubClass}`;
@@ -192,7 +192,7 @@ export class BaseClient {
     if(subClass || (queryArg && queryArg.subClass)) {
       let resolvedSubClass = subClass;
       if(queryArg && queryArg.subClass) {
-        resolvedSubClass = queryArg?.subClass;
+        resolvedSubClass = queryArg.subClass;
       }
 
       queryString += `&subClass=${resolvedSubClass}`;

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -122,9 +122,9 @@ export class BaseClient {
   protected getQueryStringArgBase(queryArg?: ITwinsQueryArgBase, subClass?: ITwinSubClass): string {
     let queryString = "";
 
-    if (subClass !== undefined ) {
+    if (subClass) {
       queryString += `subClass=${subClass}`;
-    } else if (queryArg !== undefined && queryArg.subClass !== undefined) {
+    } else if (queryArg && queryArg.subClass) {
       queryString += `subClass=${queryArg.subClass}`;
     }
 
@@ -132,23 +132,23 @@ export class BaseClient {
       return queryString;
     }
 
-    if (queryArg.includeInactive !== undefined) {
+    if (queryArg.includeInactive) {
       queryString += `&includeInactive=${queryArg.includeInactive}`;
     }
 
-    if (queryArg.top !== undefined) {
+    if (queryArg.top) {
       queryString += `&$top=${queryArg.top}`;
     }
 
-    if (queryArg.skip !== undefined) {
+    if (queryArg.skip) {
       queryString += `&$skip=${queryArg.skip}`;
     }
 
-    if (queryArg.status !== undefined) {
+    if (queryArg.status) {
       queryString += `&status=${queryArg.status}`;
     }
 
-    if (queryArg.type !== undefined) {
+    if (queryArg.type) {
       queryString += `&type=${queryArg.type}`;
     }
 
@@ -170,24 +170,24 @@ export class BaseClient {
       return queryString;
     }
 
-    if (queryArg.search !== undefined) {
-      queryString += `&includeInactive=${queryArg.search}`;
+    if (queryArg.search) {
+      queryString += `&search=${queryArg.search}`;
     }
 
-    if (queryArg.displayName !== undefined) {
-      queryString += `&$top=${queryArg.displayName}`;
+    if (queryArg.displayName) {
+      queryString += `&displayName=${queryArg.displayName}`;
     }
 
-    if (queryArg.number !== undefined) {
-      queryString += `&$skip=${queryArg.number}`;
+    if (queryArg.number) {
+      queryString += `&number=${queryArg.number}`;
     }
 
-    if (queryArg.parentId !== undefined) {
-      queryString += `&status=${queryArg.parentId}`;
+    if (queryArg.parentId) {
+      queryString += `&parentId=${queryArg.parentId}`;
     }
 
-    if (queryArg.iTwinAccountId !== undefined) {
-      queryString += `&type=${queryArg.iTwinAccountId}`;
+    if (queryArg.iTwinAccountId) {
+      queryString += `&iTwinAccountId=${queryArg.iTwinAccountId}`;
     }
 
     // trim & from start of string

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -171,7 +171,7 @@ export class BaseClient {
     }
 
     if (queryArg.search) {
-      queryString += `&search=${queryArg.search}`;
+      queryString += `&$search=${queryArg.search}`;
     }
 
     if (queryArg.displayName) {

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -123,7 +123,7 @@ export class BaseClient {
     let queryString = "";
 
     if(subClass || queryArg.subClass) {
-      queryString += `&subClass=${subClass || queryArg.subClass}`;
+      queryString += `&subClass=${subClass ?? queryArg.subClass}`;
     }
 
     if (queryArg.includeInactive) {
@@ -181,7 +181,7 @@ export class BaseClient {
     let queryString = "";
 
     if(subClass || queryArg.subClass) {
-      queryString += `&subClass=${subClass || queryArg.subClass}`;
+      queryString += `&subClass=${subClass ?? queryArg.subClass}`;
     }
 
     if (queryArg.includeInactive) {

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -11,7 +11,8 @@ import type { AxiosRequestConfig } from "axios";
 import axios from "axios";
 import type {
   ITwinsAPIResponse,
-  ITwinsQueryArg, ITwinsQueryArgBase,
+  ITwinsQueryArg,
+  ITwinsQueryArgBase,
   RepositoriesQueryArg,
 } from "./iTwinsAccessProps";
 

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -164,7 +164,7 @@ export class BaseClient {
    * @returns query string with AccessControlQueryArg applied, which should be appended to a url
    */
   protected getQueryStringArg(queryArg?: ITwinsQueryArg, subClass?: ITwinSubClass): string {
-    let queryString = this.getQueryStringArgBase({ ...queryArg }, subClass);
+    let queryString = this.getQueryStringArgBase(queryArg, subClass);
 
     if(!queryArg) {
       return queryString;
@@ -201,7 +201,10 @@ export class BaseClient {
    * @param queryArg Object container queryable properties
    * @returns query string with RepositoriesQueryArg applied, which should be appended to a url
    */
-  protected getRepositoryQueryString(queryArg: RepositoriesQueryArg): string {
+  protected getRepositoryQueryString(queryArg?: RepositoriesQueryArg): string {
+    if(!queryArg)
+      return "";
+
     let queryString = "";
 
     if (queryArg.class) {

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -123,9 +123,9 @@ export class BaseClient {
     let queryString = "";
 
     if (subClass) {
-      queryString += `&subClass=${subClass}`;
+      queryString += `subClass=${subClass}`;
     } else if (queryArg && queryArg.subClass) {
-      queryString += `&subClass=${queryArg.subClass}`;
+      queryString += `subClass=${queryArg.subClass}`;
     }
 
     if(!queryArg) {
@@ -187,9 +187,9 @@ export class BaseClient {
     let queryString = "";
 
     if (subClass) {
-      queryString += `&subClass=${subClass}`;
+      queryString += `subClass=${subClass}`;
     } else if (queryArg && queryArg.subClass) {
-      queryString += `&subClass=${queryArg.subClass}`;
+      queryString += `subClass=${queryArg.subClass}`;
     }
 
     if(!queryArg) {

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -122,13 +122,8 @@ export class BaseClient {
   protected getQueryString(queryArg?: ITwinsQueryArg, subClass?: ITwinSubClass): string {
     let queryString = "";
 
-    if(subClass || (queryArg && queryArg.subClass)) {
-      let resolvedSubClass = subClass;
-      if(queryArg && queryArg.subClass) {
-        resolvedSubClass = queryArg.subClass;
-      }
-
-      queryString += `&subClass=${resolvedSubClass}`;
+    if(subClass || queryArg?.subClass) {
+      queryString += `&subClass=${subClass ?? queryArg?.subClass}`;
     }
 
     if(!queryArg) {
@@ -189,13 +184,8 @@ export class BaseClient {
   protected getQueryStringArgBase(queryArg?: ITwinsQueryArgBase, subClass?: ITwinSubClass): string {
     let queryString = "";
 
-    if(subClass || (queryArg && queryArg.subClass)) {
-      let resolvedSubClass = subClass;
-      if(queryArg && queryArg.subClass) {
-        resolvedSubClass = queryArg.subClass;
-      }
-
-      queryString += `&subClass=${resolvedSubClass}`;
+    if(subClass || queryArg?.subClass) {
+      queryString += `&subClass=${subClass ?? queryArg?.subClass}`;
     }
 
     if(!queryArg) {

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -164,7 +164,7 @@ export class BaseClient {
    * @returns query string with AccessControlQueryArg applied, which should be appended to a url
    */
   protected getQueryStringArg(queryArg?: ITwinsQueryArg, subClass?: ITwinSubClass): string {
-    let queryString = this.getQueryStringArgBase(queryArg, subClass);
+    let queryString = this.getQueryStringArgBase({ ...queryArg }, subClass);
 
     if(!queryArg) {
       return queryString;

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -115,70 +115,6 @@ export class BaseClient {
   }
 
   /**
-   * Build a query to be appended to a URL
-   * @param queryArg Object container queryable properties
-   * @returns query string with AccessControlQueryArg applied, which should be appended to a url
-   */
-  protected getQueryString(queryArg?: ITwinsQueryArg, subClass?: ITwinSubClass): string {
-    let queryString = "";
-
-    if (subClass) {
-      queryString += `subClass=${subClass}`;
-    } else if (queryArg && queryArg.subClass) {
-      queryString += `subClass=${queryArg.subClass}`;
-    }
-
-    if(!queryArg) {
-      return queryString;
-    }
-
-    if (queryArg.includeInactive) {
-      queryString += `&includeInactive=${queryArg.includeInactive}`;
-    }
-
-    if (queryArg.top) {
-      queryString += `&$top=${queryArg.top}`;
-    }
-
-    if (queryArg.skip) {
-      queryString += `&$skip=${queryArg.skip}`;
-    }
-
-    if (queryArg.status) {
-      queryString += `&status=${queryArg.status}`;
-    }
-
-    if (queryArg.type) {
-      queryString += `&type=${queryArg.type}`;
-    }
-
-    if (queryArg.search) {
-      queryString += `&$search=${queryArg.search}`;
-    }
-
-    if (queryArg.displayName) {
-      queryString += `&displayName=${queryArg.displayName}`;
-    }
-
-    if (queryArg.number) {
-      queryString += `&number=${queryArg.number}`;
-    }
-
-    if (queryArg.parentId) {
-      queryString += `&parentId=${queryArg.parentId}`;
-    }
-
-    if (queryArg.iTwinAccountId) {
-      queryString += `&iTwinAccountId=${queryArg.iTwinAccountId}`;
-    }
-
-    // trim & from start of string
-    queryString.replace(/^&+/, "");
-
-    return queryString;
-  }
-
-  /**
     * Build a query to be appended to a URL
     * @param queryArg Object container queryable properties
     * @returns query string with AccessControlQueryArg applied, which should be appended to a url
@@ -214,6 +150,44 @@ export class BaseClient {
 
     if (queryArg.type) {
       queryString += `&type=${queryArg.type}`;
+    }
+
+    // trim & from start of string
+    queryString.replace(/^&+/, "");
+
+    return queryString;
+  }
+
+  /**
+   * Build a query to be appended to a URL
+   * @param queryArg Object container queryable properties
+   * @returns query string with AccessControlQueryArg applied, which should be appended to a url
+   */
+  protected getQueryStringArg(queryArg?: ITwinsQueryArg, subClass?: ITwinSubClass): string {
+    let queryString = this.getQueryStringArgBase(queryArg, subClass);
+
+    if(!queryArg) {
+      return queryString;
+    }
+
+    if (queryArg.search) {
+      queryString += `&includeInactive=${queryArg.search}`;
+    }
+
+    if (queryArg.displayName) {
+      queryString += `&$top=${queryArg.displayName}`;
+    }
+
+    if (queryArg.number) {
+      queryString += `&$skip=${queryArg.number}`;
+    }
+
+    if (queryArg.parentId) {
+      queryString += `&status=${queryArg.parentId}`;
+    }
+
+    if (queryArg.iTwinAccountId) {
+      queryString += `&type=${queryArg.iTwinAccountId}`;
     }
 
     // trim & from start of string

--- a/src/iTwinsAccessProps.ts
+++ b/src/iTwinsAccessProps.ts
@@ -36,14 +36,14 @@ export interface ITwinsAccess {
   queryFavoritesAsync(
     accessToken: AccessToken,
     subClass: ITwinSubClass,
-    arg?: ITwinsQueryArg
+    arg?: ITwinsQueryArgBase
   ): Promise<ITwinsAPIResponse<ITwin[]>>;
 
   /** Get recent iTwins */
   queryRecentsAsync(
     accessToken: AccessToken,
     subClass: ITwinSubClass,
-    arg?: ITwinsQueryArg
+    arg?: ITwinsQueryArgBase
   ): Promise<ITwinsAPIResponse<ITwin[]>>;
 
   /** Get the primary account ITwin */
@@ -87,6 +87,7 @@ export interface ITwin {
   image?: string | null;
   createdDateTime?: string;
   createdBy?: string;
+  geographicLocation?: string;
 }
 
 /** The simplified Repository object
@@ -142,14 +143,22 @@ export type ITwinQueryScope = "memberOfItwin" | "all";
 /** Set of optional arguments used for querying the iTwins API
  * @beta
  */
-export interface ITwinsQueryArg {
-  top?: number;
-  skip?: number;
+export interface ITwinsQueryArg extends ITwinsQueryArgBase {
   search?: string;
   displayName?: string;
   // eslint-disable-next-line id-blacklist
   number?: string;
+  parentId?: string;
+  iTwinAccountId?: string;
+}
+
+export interface ITwinsQueryArgBase {
+  subClass?: ITwinSubClass;
+  status?: string;
   type?: string;
+  top?: number;
+  skip?: number;
+  includeInactive: boolean;
   resultMode?: ITwinResultMode;
   queryScope?: ITwinQueryScope;
 }

--- a/src/iTwinsAccessProps.ts
+++ b/src/iTwinsAccessProps.ts
@@ -158,10 +158,9 @@ export interface ITwinsQueryArgBase {
   type?: string;
   top?: number;
   skip?: number;
-  includeInactive: boolean;
+  includeInactive?: boolean;
   resultMode?: ITwinResultMode;
   queryScope?: ITwinQueryScope;
-  subClass?: ITwinSubClass;
 }
 
 /** Set of optional arguments used for querying Respositories API

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -46,7 +46,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = this._baseUrl;
 
     // eslint-disable-next-line deprecation/deprecation
-    const query = this.getQueryStringArgBase(arg, subClass);
+    const query = this.getQueryStringArg(arg, subClass);
     if (query !== "")
       url += `?${query}`;
 

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -14,6 +14,7 @@ import type {
   ITwinsAccess,
   ITwinsAPIResponse,
   ITwinsQueryArg,
+  ITwinsQueryArgBase,
   ITwinSubClass,
   RepositoriesQueryArg,
   Repository,
@@ -158,12 +159,12 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
   public async queryFavoritesAsync(
     accessToken: AccessToken,
     subClass: ITwinSubClass,
-    arg?: ITwinsQueryArg
+    arg?: ITwinsQueryArgBase
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
     const headers = this.getHeaders(arg);
     let url = `${this._baseUrl}/favorites?subClass=${subClass}`;
     if (arg)
-      url += this.getQueryString(arg);
+      url += this.getQueryStringArgBase(arg);
     return this.sendGenericAPIRequest(accessToken, "GET", url, undefined, "iTwins", headers);
   }
 
@@ -176,12 +177,12 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
   public async queryRecentsAsync(
     accessToken: AccessToken,
     subClass: ITwinSubClass,
-    arg?: ITwinsQueryArg
+    arg?: ITwinsQueryArgBase
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
     const headers = this.getHeaders(arg);
     let url = `${this._baseUrl}/recents?subClass=${subClass}`;
     if (arg)
-      url += this.getQueryString(arg);
+      url += this.getQueryStringArgBase(arg);
     return this.sendGenericAPIRequest(accessToken, "GET", url, undefined, "iTwins", headers);
   }
 
@@ -216,7 +217,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
    * @param arg (Optional) iTwin query arguments
    * @protected
    */
-  protected getHeaders(arg?: ITwinsQueryArg): Record<string, string> {
+  protected getHeaders(arg?: ITwinsQueryArgBase): Record<string, string> {
     return {...this.getQueryScopeHeaders(arg && arg.queryScope), ...this.getResultModeHeaders(arg && arg.resultMode)};
   }
 

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -136,8 +136,14 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     arg?: RepositoriesQueryArg
   ): Promise<ITwinsAPIResponse<Repository[]>> {
     let url = `${this._baseUrl}/${iTwinId}/repositories`;
-    if (arg)
-      url += this.getRepositoryQueryString(arg);
+
+    if (arg) {
+      const query = this.getRepositoryQueryString(arg);
+      if(query !== "") {
+        url += `?${query}`;
+      }
+    }
+
     return this.sendGenericAPIRequest(accessToken, "GET", url, undefined, "repositories");
   }
 

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -46,7 +46,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = this._baseUrl;
 
     // eslint-disable-next-line deprecation/deprecation
-    const query = arg ? this.getQueryStringArgBase(arg, subClass) : "";
+    const query = this.getQueryStringArgBase(arg, subClass);
     if (query !== "")
       url += `?${query}`;
 
@@ -175,7 +175,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = `${this._baseUrl}/favorites`;
 
     // eslint-disable-next-line deprecation/deprecation
-    const query = arg ? this.getQueryStringArgBase(arg, subClass) : "";
+    const query = this.getQueryStringArgBase(arg, subClass);
     if (query !== "")
       url += `?${query}`;
 

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -177,7 +177,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     subClass?: ITwinSubClass,
     arg?: ITwinsQueryArgBase
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
-    const headers = this.getHeaders(arg);
+    const headers = this.getHeadersFromBase(arg);
     let url = `${this._baseUrl}/favorites`;
 
     // eslint-disable-next-line deprecation/deprecation
@@ -202,7 +202,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     subClass?: ITwinSubClass,
     arg?: ITwinsQueryArgBase
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
-    const headers = this.getHeaders(arg);
+    const headers = this.getHeadersFromBase(arg);
     let url = `${this._baseUrl}/recents`;
 
     // eslint-disable-next-line deprecation/deprecation
@@ -244,8 +244,23 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
    * @param arg (Optional) iTwin query arguments
    * @protected
    */
-  protected getHeaders(arg?: ITwinsQueryArgBase): Record<string, string> {
-    return {...this.getQueryScopeHeaders(arg && arg.queryScope), ...this.getResultModeHeaders(arg && arg.resultMode)};
+  protected getHeadersFromBase(arg?: ITwinsQueryArgBase): Record<string, string> {
+    return {
+      ...this.getQueryScopeHeaders(arg && arg.queryScope),
+      ...this.getResultModeHeaders(arg && arg.resultMode),
+    };
+  }
+
+  /**
+   * Format headers from query arguments
+   * @param arg (Optional) iTwin query arguments
+   * @protected
+   */
+  protected getHeaders(arg?: ITwinsQueryArg): Record<string, string> {
+    return {
+      ...this.getQueryScopeHeaders(arg && arg.queryScope),
+      ...this.getResultModeHeaders(arg && arg.resultMode),
+    };
   }
 
   /**

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -206,7 +206,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = `${this._baseUrl}/recents`;
 
     // eslint-disable-next-line deprecation/deprecation
-    const query = arg ? this.getQueryStringArgBase(arg, subClass) : "";
+    const query = this.getQueryStringArgBase(arg, subClass);
     if (query !== "")
       url += `?${query}`;
 

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -44,15 +44,9 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
     const headers = this.getHeaders(arg);
     let url = this._baseUrl;
-    let query = "";
+
     // eslint-disable-next-line deprecation/deprecation
-    let resolvedSubClass = subClass;
-    if(arg && arg.subClass)
-      resolvedSubClass = arg.subClass;
-    if (resolvedSubClass)
-      query += `subClass=${resolvedSubClass}`;
-    if (arg)
-      query += this.getQueryString(arg);
+    const query = arg ? this.getQueryStringArgBase(arg, subClass) : "";
     if (query !== "")
       url += `?${query}`;
 
@@ -179,15 +173,9 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
     const headers = this.getHeaders(arg);
     let url = `${this._baseUrl}/favorites`;
-    let query = "";
+
     // eslint-disable-next-line deprecation/deprecation
-    let resolvedSubClass = subClass;
-    if(arg && arg.subClass)
-      resolvedSubClass = arg.subClass;
-    if (resolvedSubClass)
-      query += `subClass=${resolvedSubClass}`;
-    if (arg)
-      query += this.getQueryStringArgBase(arg);
+    const query = arg ? this.getQueryStringArgBase(arg, subClass) : "";
     if (query !== "")
       url += `?${query}`;
 
@@ -210,15 +198,9 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
     const headers = this.getHeaders(arg);
     let url = `${this._baseUrl}/recents`;
-    let query = "";
+
     // eslint-disable-next-line deprecation/deprecation
-    let resolvedSubClass = subClass;
-    if(arg && arg.subClass)
-      resolvedSubClass = arg.subClass;
-    if (resolvedSubClass)
-      query += `subClass=${resolvedSubClass}`;
-    if (arg)
-      query += this.getQueryStringArgBase(arg);
+    const query = arg ? this.getQueryStringArgBase(arg, subClass) : "";
     if (query !== "")
       url += `?${query}`;
 

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -137,11 +137,9 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
   ): Promise<ITwinsAPIResponse<Repository[]>> {
     let url = `${this._baseUrl}/${iTwinId}/repositories`;
 
-    if (arg) {
-      const query = this.getRepositoryQueryString(arg);
-      if(query !== "") {
-        url += `?${query}`;
-      }
+    const query = this.getRepositoryQueryString(arg);
+    if(query !== "") {
+      url += `?${query}`;
     }
 
     return this.sendGenericAPIRequest(accessToken, "GET", url, undefined, "repositories");
@@ -177,7 +175,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     subClass?: ITwinSubClass,
     arg?: ITwinsQueryArgBase
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
-    const headers = this.getHeadersFromBase(arg);
+    const headers = this.getHeaders(arg);
     let url = `${this._baseUrl}/favorites`;
 
     // eslint-disable-next-line deprecation/deprecation
@@ -202,7 +200,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     subClass?: ITwinSubClass,
     arg?: ITwinsQueryArgBase
   ): Promise<ITwinsAPIResponse<ITwin[]>> {
-    const headers = this.getHeadersFromBase(arg);
+    const headers = this.getHeaders(arg);
     let url = `${this._baseUrl}/recents`;
 
     // eslint-disable-next-line deprecation/deprecation
@@ -244,19 +242,7 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
    * @param arg (Optional) iTwin query arguments
    * @protected
    */
-  protected getHeadersFromBase(arg?: ITwinsQueryArgBase): Record<string, string> {
-    return {
-      ...this.getQueryScopeHeaders(arg && arg.queryScope),
-      ...this.getResultModeHeaders(arg && arg.resultMode),
-    };
-  }
-
-  /**
-   * Format headers from query arguments
-   * @param arg (Optional) iTwin query arguments
-   * @protected
-   */
-  protected getHeaders(arg?: ITwinsQueryArg): Record<string, string> {
+  protected getHeaders(arg?: ITwinsQueryArgBase): Record<string, string> {
     return {
       ...this.getQueryScopeHeaders(arg && arg.queryScope),
       ...this.getResultModeHeaders(arg && arg.resultMode),

--- a/src/test/integration/iTwinsClient.test.ts
+++ b/src/test/integration/iTwinsClient.test.ts
@@ -399,8 +399,8 @@ describe("iTwinsClient", () => {
     chai.expect(iTwins).to.not.be.empty;
     iTwins.forEach((actualiTwin) => {
       chai.expect(actualiTwin.displayName).to.be.eq(iTwinName);
-      chai.expect(actualiTwin.class).to.be.eq(ITwinClass.Endeavor);
-      chai.expect(actualiTwin.subClass).to.be.eq(ITwinSubClass.Project);
+      chai.expect(actualiTwin.class).to.be.eq("Endeavor");
+      chai.expect(actualiTwin.subClass).to.be.eq("Project");
     });
   });
 

--- a/src/test/integration/iTwinsClient.test.ts
+++ b/src/test/integration/iTwinsClient.test.ts
@@ -399,8 +399,8 @@ describe("iTwinsClient", () => {
     chai.expect(iTwins).to.not.be.empty;
     iTwins.forEach((actualiTwin) => {
       chai.expect(actualiTwin.displayName).to.be.eq(iTwinName);
-      chai.expect(actualiTwin.class).to.be.eq("Endeavor");
-      chai.expect(actualiTwin.subClass).to.be.eq("Project");
+      chai.expect(actualiTwin.class).to.be.eq(ITwinClass.Endeavor);
+      chai.expect(actualiTwin.subClass).to.be.eq(ITwinSubClass.Project);
     });
   });
 


### PR DESCRIPTION
These endpoints did not have all the properties covered. 
- [Get my iTwins](https://developer.bentley.com/apis/itwins/operations/get-my-itwins/#get-my-itwins)
- [Get my favorite iTwins](https://developer.bentley.com/apis/itwins/operations/get-my-favorite-itwins/#get-my-favorite-itwins)
- [Get my recently used iTwins](https://developer.bentley.com/apis/itwins/operations/get-my-recently-used-itwins/#get-my-recently-used-itwins)

Missing properties:
- includeInactive
- status
- subClass
- parentId
- iTwinAccountId

By doing these changes refactored to use different interfaces