### PR TITLE
Add resources and graphics support

### DIFF
--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -71,6 +71,9 @@ export class BaseClient {
               ? response.data[property]
               : response.data,
         error: response.data.error,
+        links: response.data !== undefined && response.data.error === undefined &&
+          response.data !== "" && response.data['_links'] !== undefined
+          ? response.data['_links'] : undefined
       };
     } catch (err) {
       return {
@@ -128,7 +131,7 @@ export class BaseClient {
       queryString += `subClass=${subClass}`;
     }
 
-    if(!queryArg) {
+    if (!queryArg) {
       return queryString;
     }
 
@@ -166,7 +169,7 @@ export class BaseClient {
   protected getQueryStringArg(queryArg?: ITwinsQueryArg, subClass?: ITwinSubClass): string {
     let queryString = this.getQueryStringArgBase(queryArg, subClass);
 
-    if(!queryArg) {
+    if (!queryArg) {
       return queryString;
     }
 
@@ -202,7 +205,7 @@ export class BaseClient {
    * @returns query string with RepositoriesQueryArg applied, which should be appended to a url
    */
   protected getRepositoryQueryString(queryArg?: RepositoriesQueryArg): string {
-    if(!queryArg)
+    if (!queryArg)
       return "";
 
     let queryString = "";

--- a/src/iTwinsAccessProps.ts
+++ b/src/iTwinsAccessProps.ts
@@ -25,6 +25,18 @@ export interface ITwinsAccess {
     iTwinId: string
   ): Promise<ITwinsAPIResponse<Repository[]>>;
 
+  /** Get the resources for a repository */
+  queryRepositoryResourcesAsync(
+    accessToken: AccessToken,
+    uri: string
+  ): Promise<ITwinsAPIResponse<RepositoryResource[]>>
+
+  /** Get the graphics for a repository resource */
+  queryRepositoryResourceGraphicsAsync(
+    accessToken: AccessToken,
+    uri: string
+  ): Promise<ITwinsAPIResponse<ResourceCapabilityUri[]>>
+
   /** Get an ITwin */
   getAsync(
     accessToken: AccessToken,
@@ -98,6 +110,31 @@ export interface Repository {
   class: RepositoryClass;
   subClass: RepositorySubClass;
   uri: string;
+  capabilities?: RepositoryCapabilities;
+}
+
+export interface RepositoryCapabilities {
+  resources: RepositoryCapabilityUri;
+}
+
+export interface RepositoryCapabilityUri {
+  uri: string;
+}
+
+// TODO: What about 'next' and 'self' links?
+export interface RepositoryResource {
+  id?: string;
+  class: RepositoryClass;
+  displayName?: string;
+  capabilities?: ResourceCapabilities;
+}
+
+export interface ResourceCapabilities {
+  graphics?: ResourceCapabilityUri;
+}
+
+export interface ResourceCapabilityUri extends RepositoryCapabilityUri {
+  type: string; // 3DTiles, GEOJSON, etc
 }
 
 export enum ITwinSubClass {

--- a/src/iTwinsAccessProps.ts
+++ b/src/iTwinsAccessProps.ts
@@ -75,6 +75,16 @@ export interface ITwinsAPIResponse<T> {
   data?: T;
   status: number;
   error?: Error;
+  links?: ITwinLinks;
+}
+
+export interface ITwinLinks {
+  self?: ITwinLink;
+  next?: ITwinLink;
+}
+
+export interface ITwinLink {
+  href: string;
 }
 
 /** The ITwin object. Contains extra properties with "representation" result mode.

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -151,16 +151,14 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     accessToken: AccessToken,
     uri: string
   ): Promise<ITwinsAPIResponse<RepositoryResource[]>> {
-    const headers: Record<string, string> = { "Accept": "application/vnd.bentley.dcb-repo-api3+json" }; // Temporary
-    return this.sendGenericAPIRequest(accessToken, "GET", uri, undefined, "resources", headers);
+    return this.sendGenericAPIRequest(accessToken, "GET", uri, undefined, "resources");
   }
 
   public async queryRepositoryResourceGraphicsAsync(
     accessToken: AccessToken,
     uri: string
   ): Promise<ITwinsAPIResponse<ResourceCapabilityUri[]>> {
-    const headers: Record<string, string> = { "accept": "application/vnd.bentley.dcb-repo-api3+json" }; // Temporary
-    return this.sendGenericAPIRequest(accessToken, "GET", uri, undefined, "graphics", headers);
+    return this.sendGenericAPIRequest(accessToken, "GET", uri, undefined, "graphics");
   }
 
   /** Get itwin accessible to the user

--- a/src/iTwinsClient.ts
+++ b/src/iTwinsClient.ts
@@ -18,6 +18,8 @@ import type {
   ITwinSubClass,
   RepositoriesQueryArg,
   Repository,
+  RepositoryResource,
+  ResourceCapabilityUri,
 } from "./iTwinsAccessProps";
 
 /** Client API to access the itwins service.
@@ -138,11 +140,27 @@ export class ITwinsAccessClient extends BaseClient implements ITwinsAccess {
     let url = `${this._baseUrl}/${iTwinId}/repositories`;
 
     const query = this.getRepositoryQueryString(arg);
-    if(query !== "") {
+    if (query !== "") {
       url += `?${query}`;
     }
 
     return this.sendGenericAPIRequest(accessToken, "GET", url, undefined, "repositories");
+  }
+
+  public async queryRepositoryResourcesAsync(
+    accessToken: AccessToken,
+    uri: string
+  ): Promise<ITwinsAPIResponse<RepositoryResource[]>> {
+    const headers: Record<string, string> = { "Accept": "application/vnd.bentley.dcb-repo-api3+json" }; // Temporary
+    return this.sendGenericAPIRequest(accessToken, "GET", uri, undefined, "resources", headers);
+  }
+
+  public async queryRepositoryResourceGraphicsAsync(
+    accessToken: AccessToken,
+    uri: string
+  ): Promise<ITwinsAPIResponse<ResourceCapabilityUri[]>> {
+    const headers: Record<string, string> = { "accept": "application/vnd.bentley.dcb-repo-api3+json" }; // Temporary
+    return this.sendGenericAPIRequest(accessToken, "GET", uri, undefined, "graphics", headers);
   }
 
   /** Get itwin accessible to the user

--- a/src/test/integration/iTwinsClient.test.ts
+++ b/src/test/integration/iTwinsClient.test.ts
@@ -159,7 +159,7 @@ describe("iTwinsClient", () => {
 
   it("should get iModel resources from repository", async () => {
     // Arrange
-    const iTwinId = "fe7f2121-4715-4ff2-acb6-add99aacf8e4"; // TODO: Change back
+    const iTwinId = "e01065ed-c52b-4ddf-a326-e7845442716d";
     const iTwinsResponse: ITwinsAPIResponse<Repository[]> = await iTwinsCustomClient.queryRepositoriesAsync(
       accessToken,
       iTwinId,
@@ -167,7 +167,6 @@ describe("iTwinsClient", () => {
         class: RepositoryClass.iModels,
       }
     );
-    console.log(iTwinsResponse);
     chai.expect(iTwinsResponse).to.not.be.undefined;
     chai.expect(iTwinsResponse.status).to.be.eq(200);
     chai.expect(iTwinsResponse.data).to.not.be.empty;
@@ -188,6 +187,7 @@ describe("iTwinsClient", () => {
     chai.expect(resources.status).to.be.eq(200);
     chai.expect(resources.data).to.not.be.empty;
     chai.expect(resources.data!.length).to.be.greaterThan(0);
+    chai.expect(resources.links?.self?.href).to.not.be.undefined;
     resources.data!.forEach((resource) => {
       chai.expect(resource.class).to.be.eq("iModels");
       chai.expect(resource.displayName).to.not.be.empty;
@@ -197,7 +197,7 @@ describe("iTwinsClient", () => {
 
   it("should get iModel graphics from repository", async () => {
     // Arrange
-    const iTwinId = "fe7f2121-4715-4ff2-acb6-add99aacf8e4"; // TODO: Change back
+    const iTwinId = "e01065ed-c52b-4ddf-a326-e7845442716d";
     const iTwinsResponse: ITwinsAPIResponse<Repository[]> = await iTwinsAccessClient.queryRepositoriesAsync(
       accessToken,
       iTwinId,


### PR DESCRIPTION
Adding support for:

- Capabilities property on the repository
- Getting resources for a repo by passing the uri through as a parameter. This felt less restrictive (and more compatible with _links) than passing the repository object
- Getting graphics for a resource
- Getting the 'next' and 'self' page links